### PR TITLE
Use smart pointers in favor of new/delete for zmq socket

### DIFF
--- a/driver/xrt/include/simdevice.hpp
+++ b/driver/xrt/include/simdevice.hpp
@@ -43,7 +43,7 @@ public:
    * Destroy the Simulated Device object
    *
    */
-  virtual ~SimDevice();
+  virtual ~SimDevice() {}
 
   void call(const Options &options) override;
 

--- a/driver/xrt/src/simdevice.cpp
+++ b/driver/xrt/src/simdevice.cpp
@@ -28,11 +28,6 @@ SimDevice::SimDevice(unsigned int zmqport, unsigned int local_rank) {
   debug("SimDevice connected");
 };
 
-SimDevice::~SimDevice() {
-    if (zmq_ctx.cmd_socket != nullptr)
-       delete zmq_ctx.cmd_socket;
-}
-
 void SimDevice::start(const Options &options) {
   int function;
 

--- a/test/model/bfm/.gitignore
+++ b/test/model/bfm/.gitignore
@@ -1,0 +1,3 @@
+docs/html
+docs/latex
+docs/xml

--- a/test/model/bfm/cclo_bfm.cpp
+++ b/test/model/bfm/cclo_bfm.cpp
@@ -28,19 +28,12 @@ unsigned int call_ctr;
 CCLO_BFM::CCLO_BFM(unsigned int zmqport, unsigned int local_rank, unsigned int world_size,  const std::vector<unsigned int>& krnl_dest,
             hlslib::Stream<command_word> &callreq, hlslib::Stream<command_word> &callack,
             hlslib::Stream<stream_word> &data_cclo2krnl, hlslib::Stream<stream_word> &data_krnl2cclo,
-            int target_ctrl_stream) : 
+            int target_ctrl_stream) :
             callreq(callreq), callack(callack), data_cclo2krnl(data_cclo2krnl), data_krnl2cclo(data_krnl2cclo), target_ctrl_stream(target_ctrl_stream) {
     //create ZMQ context
     std::cout << "CCLO BFM connecting to ZMQ on starting port " + std::to_string(zmqport) + " for rank " + std::to_string(local_rank) << std::endl;
     zmq_ctx = zmq_client_intf(zmqport, local_rank, krnl_dest, world_size);
     std::cout << "CCLO BFM connected" << std::endl;
-}
-
-CCLO_BFM::~CCLO_BFM() {
-    // Free all used ZMQ sockets
-    delete zmq_ctx.cmd_socket;
-    delete zmq_ctx.krnl_rx_socket;
-    delete zmq_ctx.krnl_tx_socket;
 }
 
 //TODO: utility function, finds the registered SimBuffer

--- a/test/model/bfm/cclo_bfm.h
+++ b/test/model/bfm/cclo_bfm.h
@@ -23,7 +23,7 @@
 
 /**
  * @brief Class providing a bus-functional model (at HLS Stream level) of the ACCL CCLO kernel. Connects to the emulator/simulator.
- * 
+ *
  */
 class CCLO_BFM{
     private:
@@ -37,13 +37,13 @@ class CCLO_BFM{
         std::vector<std::thread> threads;
         int target_ctrl_stream;
 
-        //hlslib::Stream<std::vector<ACCL::SimBuffer *>> buf_args; 
+        //hlslib::Stream<std::vector<ACCL::SimBuffer *>> buf_args;
         //std::vector<ACCL::SimBuffer *> buffers;
 
     public:
         /**
          * @brief Construct a new CCLO_BFM object
-         * 
+         *
          * @param zmqport Number of port which connects to the ACCL emulator/simulator
          * @param local_rank ID of local rank
          * @param world_size Total number of ranks
@@ -62,17 +62,17 @@ class CCLO_BFM{
         * @brief Deconstructer of the CCLO_BFM object
         *
         */
-        ~CCLO_BFM();
-        
+        ~CCLO_BFM() {}
+
         /**
          * @brief Start BFM
-         * 
+         *
          */
         void run();
 
         /**
          * @brief Stop BFM
-         * 
+         *
          */
         void stop();
         //void register_buffer(ACCL::SimBuffer *buf)

--- a/test/model/zmq/zmq_client.cpp
+++ b/test/model/zmq/zmq_client.cpp
@@ -28,7 +28,7 @@ zmq_intf_context zmq_client_intf(unsigned int starting_port, unsigned int local_
     zmq_intf_context ctx;
     const string endpoint_base = "tcp://127.0.0.1:";
 
-    ctx.cmd_socket = new zmqpp::socket(ctx.context, zmqpp::socket_type::request);
+    ctx.cmd_socket = std::make_unique<zmqpp::socket>(ctx.context, zmqpp::socket_type::request);
 
     string cmd_endpoint = endpoint_base + to_string(starting_port + local_rank);
     cout << "Endpoint: " << cmd_endpoint << endl;
@@ -42,8 +42,8 @@ zmq_intf_context zmq_client_intf(unsigned int starting_port, unsigned int local_
     cout << "ZMQ Client Command Context established for rank " << local_rank << endl;
 
     if(krnl_dest.size() > 0){
-        ctx.krnl_tx_socket = new zmqpp::socket(ctx.context, zmqpp::socket_type::sub);
-        ctx.krnl_rx_socket = new zmqpp::socket(ctx.context, zmqpp::socket_type::pub);
+        ctx.krnl_tx_socket = std::make_unique<zmqpp::socket>(ctx.context, zmqpp::socket_type::sub);
+        ctx.krnl_rx_socket = std::make_unique<zmqpp::socket>(ctx.context, zmqpp::socket_type::pub);
 
         //bind to tx socket
         string krnl_endpoint = endpoint_base + to_string(starting_port+2*world_size+local_rank);

--- a/test/model/zmq/zmq_common.h
+++ b/test/model/zmq/zmq_common.h
@@ -17,25 +17,26 @@
 #pragma once
 #include <json/json.h>
 #include <zmqpp/zmqpp.hpp>
+#include <memory>
 
 /**
  * @brief ZMQ interface context, consisting of ZMQ sockets
- * 
+ *
  */
 struct zmq_intf_context{
     zmqpp::context context;
-    zmqpp::socket *cmd_socket;
-    zmqpp::socket *eth_tx_socket;
-    zmqpp::socket *eth_rx_socket;
-    zmqpp::socket *krnl_tx_socket;
-    zmqpp::socket *krnl_rx_socket;
+    std::unique_ptr<zmqpp::socket> cmd_socket;
+    std::unique_ptr<zmqpp::socket> eth_tx_socket;
+    std::unique_ptr<zmqpp::socket> eth_rx_socket;
+    std::unique_ptr<zmqpp::socket> krnl_tx_socket;
+    std::unique_ptr<zmqpp::socket> krnl_rx_socket;
     bool stop = false;
     zmq_intf_context() : context() {}
 };
 
 /**
  * @brief Convert a ZMQ message to JSON
- * 
+ *
  * @param message Reference to the ZMQ message, as received from the socket
  * @return Json::Value The JSON equivalent
  */
@@ -43,7 +44,7 @@ Json::Value to_json(zmqpp::message &message);
 
 /**
  * @brief Convert a JSON to a ZMQ message
- * 
+ *
  * @param request_json The JSON input
  * @param request Reference to the ZMQ message, ready for sending
  */

--- a/test/model/zmq/zmq_server.cpp
+++ b/test/model/zmq/zmq_server.cpp
@@ -33,11 +33,11 @@ zmq_intf_context zmq_server_intf(unsigned int starting_port, unsigned int local_
     zmq_intf_context ctx;
 
     logger = &log;
-    ctx.cmd_socket = new zmqpp::socket(ctx.context, zmqpp::socket_type::reply);
-    ctx.eth_tx_socket = new zmqpp::socket(ctx.context, zmqpp::socket_type::pub);
-    ctx.eth_rx_socket = new zmqpp::socket(ctx.context, zmqpp::socket_type::sub);
-    ctx.krnl_tx_socket = new zmqpp::socket(ctx.context, zmqpp::socket_type::pub);
-    ctx.krnl_rx_socket = new zmqpp::socket(ctx.context, zmqpp::socket_type::sub);
+    ctx.cmd_socket = std::make_unique<zmqpp::socket>(ctx.context, zmqpp::socket_type::reply);
+    ctx.eth_tx_socket = std::make_unique<zmqpp::socket>(ctx.context, zmqpp::socket_type::pub);
+    ctx.eth_rx_socket = std::make_unique<zmqpp::socket>(ctx.context, zmqpp::socket_type::sub);
+    ctx.krnl_tx_socket = std::make_unique<zmqpp::socket>(ctx.context, zmqpp::socket_type::pub);
+    ctx.krnl_rx_socket = std::make_unique<zmqpp::socket>(ctx.context, zmqpp::socket_type::sub);
 
     const string endpoint_base = "tcp://127.0.0.1:";
 
@@ -654,7 +654,7 @@ void serve_zmq(zmq_intf_context *ctx,
                         resp = 0;
                     }
                     response["status"] = (resp & 0x2) ? 0 : 1;
-                    
+
                 } else {
                     //we handle this request checking the status stream
                     if(callack.IsEmpty()){


### PR DESCRIPTION
Could you try this out and see if it works? I think this is a better solution than manually deleting the sockets.